### PR TITLE
Add image build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,75 @@
+name: Build and push a Docker image
+
+on:
+  push:
+    branches: ["main"]
+    tags: [ 'v*.*.*' ]
+
+  workflow_dispatch:
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  #IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,amd64'
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=ref,event=branch
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: VERSION=${{github.ref_name}}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:lts-alpine AS build
+
+WORKDIR /app
+COPY . /app
+
+RUN npm install
+RUN npm run build
+
+FROM node:lts-alpine
+
+WORKDIR /app
+
+COPY --from=build /app/out /app
+RUN npm install -g serve
+
+EXPOSE 3000
+
+CMD ["npx", "serve", "."]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A real-time screen sharing application built with Next.js, WebRTC, and PeerJS. Create or join rooms to share your screen with others instantly.
 
+## 🚦 Run 
+
+```bash
+docker run -p 3000:3000 -d --name screen-share ghcr.io/tonghohin/screen-share
+```
+
 ## 🚀 Features
 
 -   Real-time screen sharing

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+services:
+  screen-share:
+    build: .
+    container_name: screen-share
+    command : ["npx", "serve", "."]
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5


### PR DESCRIPTION
Adding a build action based on the previous PR #5 

This will rebuild the main tag when pushed to main branch. It will also build a new image with tags v1, v1.0, v1.0.0 when tagging the branch with v1.0.0 

The image is pushed the ghcr repository using the built in Github credentials. The image will be listed in the package list (you might need to enable it) 